### PR TITLE
Re-use bids for ad units of the same type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "2.40.0-pre",
+  "version": "2.42.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5032,7 +5032,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -9378,7 +9378,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }

--- a/src/modifications/sblyReuseBidsAcrossDepth.js
+++ b/src/modifications/sblyReuseBidsAcrossDepth.js
@@ -1,0 +1,178 @@
+import includes from 'core-js/library/fn/array/includes';
+
+const utils = require('../utils.js');
+
+function find(array, fn) {
+  return array.filter(fn)[0];
+}
+
+function assignBidsByMaximum(adUnitCodes, bidsGroupedByBaseAdUnitCode, assignedAdIds) {
+  const mapping = {};
+  adUnitCodes.forEach(adUnitCode => {
+    const maximumByUnitSpecific = bidsGroupedByBaseAdUnitCode[adUnitCode]
+  })
+}
+
+function groupByFunction(xs, func) {
+  return xs.reduce(function(rv, x) {
+    (rv[func(x)] = rv[func(x)] || []).push(x);
+    return rv;
+  }, {});
+}
+
+function canUseBidForSharedPool(bid) {
+  const biddersWithIndividualPlacements = ['ix', 'sovrn'];
+  return !includes(biddersWithIndividualPlacements, bid.bidder.toLowerCase()) && isDynamicRepeatingAdUnit(bid.adUnitCode);
+}
+
+function getBaseAdUnitCode(adUnitCode) {
+  return adUnitCode.replace(/-depth-\d+/gm, '');
+}
+
+function isDynamicRepeatingAdUnit(adUnitCode) {
+  return new RegExp(/-depth-\d+/gm).test(adUnitCode)
+}
+
+function sortedBidsByHighestCPM(bidsGroupedByAdUnitCode) {
+  const sorted = {};
+  Object.keys(bidsGroupedByAdUnitCode).forEach(key => {
+    const bidsForAdCode = bidsGroupedByAdUnitCode[key];
+    sorted[key] = bidsForAdCode.sort((bid, otherBid) => otherBid.cpm - bid.cpm);
+  })
+  return sorted;
+}
+
+export function getWinningBidsWithSharing(originalWinningBids, adUnitCodes, bidsReceived) {
+  const bidsGroupedByBaseAdUnitCode = sortedBidsByHighestCPM(groupByFunction(bidsReceived, (bid) => {
+    if (canUseBidForSharedPool(bid)) {
+      return getBaseAdUnitCode(bid.adUnitCode)
+    } else {
+      return bid.adUnitCode;
+    }
+  }));
+
+  const groupedByUnitCode = originalWinningBids.reduce((acc, next) => {
+    acc[next.adUnitCode] = next;
+    return acc;
+  }, {})
+
+  utils.logMessage('Grouped', bidsGroupedByBaseAdUnitCode, groupedByUnitCode)
+
+  const winningBidAssignments = {};
+  const assignedAdIds = new Set();
+
+  // assignment by most constrained
+  adUnitCodes.forEach(adUnitCode => {
+    const mostConstrainedWinningBid = (bidsGroupedByBaseAdUnitCode[adUnitCode] || [])[0];
+    if (mostConstrainedWinningBid) {
+      winningBidAssignments[adUnitCode] = mostConstrainedWinningBid;
+      assignedAdIds.add(mostConstrainedWinningBid.adId)
+    } else {
+      winningBidAssignments[adUnitCode] = null;
+    }
+  })
+
+  // get sorted list of lowest cpm to highest cpm ad unit codes
+  const sortedAdUnitCodesByLowestCPM = Object.keys(winningBidAssignments).sort((adUnitCode, otherAdUnitCode) => {
+    const bidCPM = winningBidAssignments[adUnitCode] ? winningBidAssignments[adUnitCode].cpm : 0;
+    const otherBidCPM = winningBidAssignments[otherAdUnitCode] ? winningBidAssignments[otherAdUnitCode].cpm : 0;
+    return bidCPM - otherBidCPM;
+  });
+
+  utils.logMessage('By lowest value', sortedAdUnitCodesByLowestCPM.map(adUnitCode => {
+    return { adUnitCode, cpm: (winningBidAssignments[adUnitCode] || {}).cpm || 0 }
+  }))
+
+  // re-assign least value to shared pool
+  sortedAdUnitCodesByLowestCPM.forEach(adUnitCode => {
+    if (isDynamicRepeatingAdUnit(adUnitCode)) {
+      const currentBid = winningBidAssignments[adUnitCode];
+      const possibleReplacementBids = bidsGroupedByBaseAdUnitCode[getBaseAdUnitCode(adUnitCode)] || [];
+      const betterBid = find(possibleReplacementBids, (bid) => {
+        const isNotAssigned = !assignedAdIds.has(bid.adId);
+        const isHigherCPM = bid.cpm > ((currentBid || {}).cpm || 0)
+        return isNotAssigned && isHigherCPM;
+      })
+      if (betterBid) {
+        assignedAdIds.add(betterBid.adId);
+        winningBidAssignments[adUnitCode] = betterBid;
+      }
+    }
+  })
+
+  const changeSummaries = [];
+
+  // have as little change as possible with original bids
+  adUnitCodes.forEach(adUnitCode => {
+    const winningBid = winningBidAssignments[adUnitCode]
+    if (isDynamicRepeatingAdUnit(adUnitCode) && winningBid) {
+      if (winningBid.adUnitCode !== adUnitCode) {
+        const adUnitCodeWithOriginalBid = find(adUnitCodes,  code => {
+          return winningBidAssignments[code] ? winningBidAssignments[code].adUnitCode === adUnitCode : false;
+        })
+        if (adUnitCodeWithOriginalBid) {
+          const originalBid = winningBidAssignments[adUnitCodeWithOriginalBid];
+          winningBidAssignments[adUnitCodeWithOriginalBid] = winningBid;
+          winningBidAssignments[adUnitCode] = originalBid;
+        }
+
+        const priorBid = groupedByUnitCode[adUnitCode] || {};
+        const finalBid = winningBidAssignments[adUnitCode];
+
+        if (adUnitCode === finalBid.adUnitCode) {
+          changeSummaries.push({
+            adUnitCode,
+            status: 'NOT CHANGED - Swapped Successfully',
+          })
+        } else {
+          changeSummaries.push({
+            adUnitCode,
+            status: 'CHANGED - Better Bid Found',
+            adUnitCodeUsed: finalBid.adUnitCode,
+            priorCPM: priorBid.cpm || 0,
+            finalCPM: finalBid.cpm,
+            gain: finalBid.cpm - priorBid.cpm,
+          })
+        }
+      } else {
+        changeSummaries.push({
+          adUnitCode,
+          status: 'NOT CHANGED - Original Bid',
+        })
+      }
+    } else {
+      changeSummaries.push({
+        adUnitCode,
+        status: 'NOT CHANGED - Not Dynamic Depth Bid or No Bid'
+      })
+    }
+  })
+
+  const originalTotal = originalWinningBids.reduce((acc, next) => acc + next.cpm, 0);
+  const reassignedBidTotal = Object.values(winningBidAssignments).filter(bid => bid).reduce((acc, next) => acc + next.cpm, 0);
+  const gainAmount = reassignedBidTotal - originalTotal;
+  const gainPercentage = gainAmount / originalTotal;
+  const hasEnoughGain = gainAmount > 0.075 && gainPercentage > 0.005;
+
+  utils.logMessage('Change Summary', changeSummaries, 'Final Assignments', winningBidAssignments);
+  utils.logMessage('Gain Summary', { hasEnoughGain, gainAmount, reassignedBidTotal, originalTotal, gainPercentage: Math.round(gainPercentage * 100, 6) });
+
+  if (hasEnoughGain) {
+    // map out final winning bids
+    const winningBids = Object.keys(winningBidAssignments).map(adUnitCode => {
+      const winningBid = winningBidAssignments[adUnitCode];
+      if (winningBid) {
+        winningBid.adUnitCode = adUnitCode;
+        return winningBid;
+      } else {
+        return null
+      }
+    }).filter(bid => bid);
+
+    utils.logMessage('Using Modified Winning Bids', winningBids.reduce((acc, next) => Object.assign(acc, { [next.adUnitCode]: next }), {}));
+    return winningBids;
+  } else {
+    utils.logMessage('Using Original Winning Bids', originalWinningBids.reduce((acc, next) => Object.assign(acc, { [next.adUnitCode]: next }), {}));
+    return originalWinningBids;
+  }
+}

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -840,4 +840,26 @@ $$PREBID_GLOBAL$$.processQueue = function() {
   processQueue($$PREBID_GLOBAL$$.cmd);
 };
 
+// Sbly Prebid Modifications
+$$PREBID_GLOBAL$$.getAllBidResponses  = function () {
+  return getAllBidResponses('getBidsReceived');
+}
+
+function getAllBidResponses(type) {
+  const responses = auctionManager[type]()
+    .filter(utils.bind.call(adUnitsFilter, this, auctionManager.getAdUnitCodes()));
+
+  return JSON.parse(JSON.stringify(responses
+    .map(bid => bid.adUnitCode)
+    .filter(uniques).map(adUnitCode => responses
+      .filter(bid => bid.adUnitCode === adUnitCode))
+    .filter(bids => bids && bids[0] && bids[0].adUnitCode)
+    .map(bids => {
+      return {
+        [bids[0].adUnitCode]: { bids }
+      };
+    })
+    .reduce((a, b) => Object.assign(a, b), {}))); 
+}
+
 export default $$PREBID_GLOBAL$$;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
